### PR TITLE
Improve Scalacheck integration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,9 +21,9 @@ lazy val shared =
     .settings(
       libraryDependencies ++= Seq(
         "io.monix" %%% "minitest" % Versions.miniTestVersion % "test",
-        "io.monix" %%% "minitest-laws" % Versions.miniTestVersion % "test",
         // so far, shapeless is only used to derive arbitraries -> test only
-        "com.chuusai" %%% "shapeless" % Versions.shapelessVersion % "test"
+        "com.chuusai" %%% "shapeless" % Versions.shapelessVersion % "test",
+        "org.scalacheck" %%% "scalacheck" % Versions.scalaCheckVersion % "test"
       ),
       libraryDependencies ++= Seq(
         "io.circe" %%% "circe-core"
@@ -42,8 +42,7 @@ lazy val client =
       mainClass in Compile := Some("io.github.mahh.doko.client.Client"),
       libraryDependencies ++= Seq(
         "org.scala-js" %%% "scalajs-dom" % Versions.scalaJsDomVersion,
-        "io.monix" %%% "minitest" % Versions.miniTestVersion % "test",
-        "io.monix" %%% "minitest-laws" % Versions.miniTestVersion % "test"
+        "io.monix" %%% "minitest" % Versions.miniTestVersion % "test"
       ),
       // TODO: add cats explicitly here since (it is used via transitive dependency)
       libraryDependencies ++= Seq(
@@ -52,15 +51,14 @@ lazy val client =
         "io.circe" %%% "circe-parser"
       ).map(_ % Versions.circeVersion)
     )
-    .dependsOn(sharedJs)
+    .dependsOn(sharedJs % "compile->compile;test->test")
 
 lazy val logic =
   project.in(file("logic"))
     .settings(sharedSettings)
     .settings(
       libraryDependencies ++= Seq(
-        "io.monix" %% "minitest" % Versions.miniTestVersion % "test",
-        "io.monix" %% "minitest-laws" % Versions.miniTestVersion % "test"
+        "io.monix" %% "minitest" % Versions.miniTestVersion % "test"
       )
     )
     .dependsOn(sharedJvm % "compile->compile;test->test")
@@ -73,8 +71,7 @@ lazy val server =
         "com.typesafe.akka" %% "akka-stream-typed" % Versions.akkaVersion,
         "com.typesafe.akka" %% "akka-http" % Versions.akkaHttpVersion,
         "ch.qos.logback" % "logback-classic" % Versions.logBackVersion,
-        "io.monix" %% "minitest" % Versions.miniTestVersion % "test",
-        "io.monix" %% "minitest-laws" % Versions.miniTestVersion % "test"
+        "io.monix" %% "minitest" % Versions.miniTestVersion % "test"
       ),
       libraryDependencies ++= Seq(
         "io.circe" %% "circe-core",
@@ -88,6 +85,6 @@ lazy val server =
       }.taskValue,
       watchSources ++= (watchSources in client).value
     )
-    .dependsOn(sharedJvm, logic)
+    .dependsOn(sharedJvm % "compile->compile;test->test", logic)
 
 

--- a/logic/src/test/scala/io/github/mahh/doko/logic/game/FullGameStateSpec.scala
+++ b/logic/src/test/scala/io/github/mahh/doko/logic/game/FullGameStateSpec.scala
@@ -4,8 +4,8 @@ import io.github.mahh.doko.logic.game.FullGameStateSpec.RichFullGameState
 import io.github.mahh.doko.shared.game.GameState
 import io.github.mahh.doko.shared.player.PlayerAction
 import io.github.mahh.doko.shared.player.PlayerPosition
+import io.github.mahh.doko.shared.testutils.Checkers
 import minitest.SimpleTestSuite
-import minitest.laws.Checkers
 
 import scala.language.implicitConversions
 

--- a/logic/src/test/scala/io/github/mahh/doko/logic/game/TeamAnalyzerSpec.scala
+++ b/logic/src/test/scala/io/github/mahh/doko/logic/game/TeamAnalyzerSpec.scala
@@ -3,8 +3,8 @@ package io.github.mahh.doko.logic.game
 import io.github.mahh.doko.shared.bids.Bid
 import io.github.mahh.doko.shared.player.PlayerPosition
 import io.github.mahh.doko.shared.table.TableMap
+import io.github.mahh.doko.shared.testutils.Checkers
 import minitest.SimpleTestSuite
-import minitest.laws.Checkers
 import org.scalacheck.Prop
 import org.scalacheck.Prop.AnyOperators
 

--- a/logic/src/test/scala/io/github/mahh/doko/logic/score/ScoreAnalyzerSpec.scala
+++ b/logic/src/test/scala/io/github/mahh/doko/logic/score/ScoreAnalyzerSpec.scala
@@ -11,8 +11,8 @@ import io.github.mahh.doko.shared.player.PlayerPosition.Player3
 import io.github.mahh.doko.shared.player.PlayerPosition.Player4
 import io.github.mahh.doko.shared.score.Score
 import io.github.mahh.doko.shared.table.TableMap
+import io.github.mahh.doko.shared.testutils.Checkers
 import minitest.SimpleTestSuite
-import minitest.laws.Checkers
 import org.scalacheck.Prop
 
 object ScoreAnalyzerSpec extends SimpleTestSuite with Checkers {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -9,5 +9,6 @@ object Versions {
   val scalaJsDomVersion = "1.0.0"
   val shapelessVersion = "2.3.3"
   val miniTestVersion = "2.8.2"
+  val scalaCheckVersion = "1.14.3"
 
 }

--- a/shared/src/test/scala/io/github/mahh/doko/shared/testutils/Checkers.scala
+++ b/shared/src/test/scala/io/github/mahh/doko/shared/testutils/Checkers.scala
@@ -1,0 +1,27 @@
+package io.github.mahh.doko.shared.testutils
+
+import minitest.api.Asserts.fail
+import org.scalacheck.Prop
+import org.scalacheck.Test
+import org.scalacheck.Test.Parameters
+import org.scalacheck.util.Pretty
+import org.scalacheck.util.Pretty.Params
+
+/**
+ * Scalacheck integration.
+ *
+ * Inspired by minitest-laws, but with Pretty-Params (and increased default-verbosity).
+ */
+trait Checkers {
+
+  def checkParams: Parameters = Test.Parameters.default
+
+  def prettyParams: Params = Params(1)
+
+  def check(prop: Prop, config: Parameters = checkParams, prettyParams: Params = prettyParams): Unit = {
+    val result = Test.check(config, prop)
+    val reason = Pretty.pretty(result, prettyParams)
+    if (!result.passed) fail(reason)
+  }
+
+}

--- a/shared/src/test/scala/io/github/mahh/doko/shared/testutils/GenUtilsSpec.scala
+++ b/shared/src/test/scala/io/github/mahh/doko/shared/testutils/GenUtilsSpec.scala
@@ -1,7 +1,6 @@
 package io.github.mahh.doko.shared.testutils
 
 import minitest.SimpleTestSuite
-import minitest.laws.Checkers
 import org.scalacheck.Prop
 import org.scalacheck.Prop.AnyOperators
 


### PR DESCRIPTION
minitest-laws does not support printing
the stack trace of an exception that was
thrown on property evaluation.