### PR TITLE
Make excess clients spectators

### DIFF
--- a/server/src/main/scala/io/github/mahh/doko/server/tableactor/IncomingAction.scala
+++ b/server/src/main/scala/io/github/mahh/doko/server/tableactor/IncomingAction.scala
@@ -9,11 +9,7 @@ import io.github.mahh.doko.shared.player.PlayerPosition
 /**
  * Messages that are sent to the `GameActor`.
  */
-private[server] trait IncomingAction {
-
-  val playerId: UUID
-
-}
+private[server] trait IncomingAction
 
 object IncomingAction {
 
@@ -42,11 +38,22 @@ object IncomingAction {
   ) extends IncomingAction
 
   /**
-   * Incoming socket connection has been fully disposed (i.e. the actor for outgoing messages has died).
+   * Incoming socket connection of a player has been fully disposed.
+   *
+   * (This is send via deathwatch when the actor for outgoing messages has died.)
    */
-  case class ReceiverDied(
+  case class PlayerReceiverDied(
     playerId: UUID,
     pos: PlayerPosition,
+    receiver: ActorRef[OutgoingAction]
+  ) extends IncomingAction
+
+  /**
+   * Incoming socket connection of a spectator has been fully disposed.
+   *
+   * (This is send via deathwatch when the actor for outgoing messages has died.)
+   */
+  case class SpectatorReceiverDied(
     receiver: ActorRef[OutgoingAction]
   ) extends IncomingAction
 }

--- a/server/src/main/scala/io/github/mahh/doko/server/tableactor/TableActor.scala
+++ b/server/src/main/scala/io/github/mahh/doko/server/tableactor/TableActor.scala
@@ -11,7 +11,9 @@ import io.github.mahh.doko.logic.rules.Rules
 import io.github.mahh.doko.server.tableactor.IncomingAction.IncomingMessageFromClient
 import io.github.mahh.doko.server.tableactor.IncomingAction.PlayerJoined
 import io.github.mahh.doko.server.tableactor.IncomingAction.PlayerLeaving
-import io.github.mahh.doko.server.tableactor.IncomingAction.ReceiverDied
+import io.github.mahh.doko.server.tableactor.IncomingAction.PlayerReceiverDied
+import io.github.mahh.doko.server.tableactor.IncomingAction.SpectatorReceiverDied
+import io.github.mahh.doko.server.tableactor.OutgoingAction.NewMessageToClient
 import io.github.mahh.doko.shared.msg.MessageToClient
 import io.github.mahh.doko.shared.msg.MessageToClient.GameStateMessage
 import io.github.mahh.doko.shared.msg.MessageToClient.PlayersMessage
@@ -27,14 +29,23 @@ import org.slf4j.Logger
  */
 object TableActor {
 
-  private case class Players(
-    byUuid: Map[UUID, (PlayerPosition, Set[ActorRef[OutgoingAction]])] = Map.empty
+  /**
+   * Holds `ActorRef`s of all connected clients
+   *
+   * @param byUuid     The players by id.
+   * @param spectators Spectators (not playing, but may see what is being played).
+   */
+  private case class Clients(
+    byUuid: Map[UUID, (PlayerPosition, Set[ActorRef[OutgoingAction]])] = Map.empty,
+    spectators: Set[ActorRef[OutgoingAction]] = Set.empty
   ) {
     val byPos: Map[PlayerPosition, Set[ActorRef[OutgoingAction]]]= byUuid.values.toMap
 
     val isComplete: Boolean = byPos.size >= PlayerPosition.All.size
 
-    def withPlayer(id: UUID, actorRef: ActorRef[OutgoingAction], pos: PlayerPosition): Players = {
+    def allReceivers: Set[ActorRef[OutgoingAction]] = spectators ++ byPos.values.flatten
+
+    def withPlayer(id: UUID, actorRef: ActorRef[OutgoingAction], pos: PlayerPosition): Clients = {
       val existingOpt = byUuid.get(id)
       if (existingOpt.exists { case (p, _) => p != pos }) {
         this
@@ -45,7 +56,7 @@ object TableActor {
       }
     }
 
-    def withoutReceiver(id: UUID, actorRef: ActorRef[OutgoingAction]): Players = {
+    def withoutReceiver(id: UUID, actorRef: ActorRef[OutgoingAction]): Clients = {
       byUuid.get(id).fold(this) { case (pos, refs) =>
         copy(byUuid + (id -> (pos, refs - actorRef)))
       }
@@ -53,32 +64,40 @@ object TableActor {
   }
 
   private case class State(
-    players: Players,
+    clients: Clients,
     tableState: FullTableState
   ) {
 
-    def tellAll(msg: OutgoingAction): Unit = players.byPos.values.flatten.foreach(_ ! msg)
-
-
-    def tellFullStateTo(player: UUID): Unit = {
-      players.byUuid.get(player).foreach { case (pos, replyTos) =>
-        def tell[A](getA: FullTableState => A, msgFactory: A => MessageToClient): Unit = {
-          val msg = OutgoingAction.NewMessageToClient(msgFactory(getA(tableState)))
-          replyTos.foreach(_ ! msg)
-        }
-        tell(_.playerNames, PlayersMessage.apply)
-        tell(_.totalScores, TotalScoresMessage.apply)
-        tell(_.missingPlayers, PlayersOnPauseMessage.apply)
-
-        tableState.playerStates.get(pos).foreach { ps =>
-          replyTos.foreach(_ ! OutgoingAction.NewMessageToClient(GameStateMessage(ps)))
-        }
-      }
+    private def tellAll(msg: OutgoingAction): Unit = {
+      clients.allReceivers.foreach(_ ! msg)
     }
 
-    def tellJoiningMessagesTo(actorRef: ActorRef[OutgoingAction]): Unit = {
-      actorRef ! OutgoingAction.NewMessageToClient(MessageToClient.Joining)
-      actorRef ! OutgoingAction.NewMessageToClient(PlayersMessage(tableState.playerNames))
+    def tellFullStateTo(actorRefs: Set[ActorRef[OutgoingAction]], posOpt: Option[PlayerPosition]): Unit = {
+      def tell[A](getA: FullTableState => A, msgFactory: A => MessageToClient): Unit = {
+        val msg = NewMessageToClient(msgFactory(getA(tableState)))
+        actorRefs.foreach(_ ! msg)
+      }
+
+      tell(_.playerNames, PlayersMessage.apply)
+      tell(_.totalScores, TotalScoresMessage.apply)
+      tell(_.missingPlayers, PlayersOnPauseMessage.apply)
+
+      val gameState =
+        posOpt.flatMap(tableState.playerStates.get).getOrElse(tableState.gameState.spectatorState)
+      actorRefs.foreach(_ ! NewMessageToClient(GameStateMessage(gameState)))
+    }
+
+    def tellJoiningMessages(actorRef: ActorRef[OutgoingAction]): Unit = {
+      actorRef ! NewMessageToClient(MessageToClient.Joining)
+      actorRef ! NewMessageToClient(PlayersMessage(tableState.playerNames))
+    }
+
+    def tellWelcomeMessages(actorRef: ActorRef[OutgoingAction], posOpt: Option[PlayerPosition]): Unit = {
+      if (clients.isComplete) {
+        tellFullStateTo(Set(actorRef), posOpt)
+      } else {
+        tellJoiningMessages(actorRef)
+      }
     }
 
     def updateGameStateAndTellPlayers(
@@ -90,7 +109,7 @@ object TableActor {
       def tellAllIfChanged[A](getA: FullTableState => A, msgFactory: A => MessageToClient): Unit = {
         val newA = getA(newTableState)
         if (getA(tableState) != newA || force) {
-          val msg = OutgoingAction.NewMessageToClient(msgFactory(newA))
+          val msg = NewMessageToClient(msgFactory(newA))
           tellAll(msg)
         }
       }
@@ -102,12 +121,18 @@ object TableActor {
       for {
         (pos, ps) <- newTableState.playerStates
         if force || !tableState.playerStates.get(pos).contains(ps)
-        actors <- players.byPos.get(pos)
+        actors <- clients.byPos.get(pos)
         actor <- actors
       } {
         log.trace(s"Telling this to $pos: $ps")
-        actor ! OutgoingAction.NewMessageToClient(GameStateMessage(ps))
+        actor ! NewMessageToClient(GameStateMessage(ps))
       }
+      if (clients.spectators.nonEmpty &&
+        (force || tableState.gameState.spectatorState != newTableState.gameState.spectatorState)) {
+        val spectatorState = newTableState.gameState.spectatorState
+        clients.spectators.foreach(_ ! NewMessageToClient(GameStateMessage(spectatorState)))
+      }
+
       copy(tableState = newTableState)
     }
 
@@ -117,12 +142,21 @@ object TableActor {
       actorRef: ActorRef[OutgoingAction],
       pos: PlayerPosition
     ): State = {
-      ctx.watchWith(actorRef, ReceiverDied(id, pos, actorRef))
-      copy(players = players.withPlayer(id, actorRef, pos))
+      ctx.watchWith(actorRef, PlayerReceiverDied(id, pos, actorRef))
+      copy(clients = clients.withPlayer(id, actorRef, pos))
     }
 
     def withoutReceiver(id: UUID, actorRef: ActorRef[OutgoingAction]): State = {
-      copy(players = players.withoutReceiver(id, actorRef))
+      copy(clients = clients.withoutReceiver(id, actorRef))
+    }
+
+    def withSpectator(ctx: ActorContext[IncomingAction], actorRef: ActorRef[OutgoingAction]): State = {
+      ctx.watchWith(actorRef, SpectatorReceiverDied(actorRef))
+      copy(clients = clients.copy(spectators = clients.spectators + actorRef))
+    }
+
+    def withoutSpectator(actorRef: ActorRef[OutgoingAction]): State = {
+      copy(clients = clients.copy(spectators = clients.spectators - actorRef))
     }
   }
 
@@ -133,61 +167,59 @@ object TableActor {
   private def behavior(state: State): Behavior[IncomingAction] = Behaviors.receive[IncomingAction] { (ctx, msg) =>
     ctx.log.trace(s"Received: $msg")
     msg match {
-      case j: PlayerJoined if state.players.byUuid.contains(j.playerId) =>
-        val (pos, _) = state.players.byUuid(j.playerId)
+      case j: PlayerJoined if state.clients.byUuid.contains(j.playerId) =>
+        val (pos, _) = state.clients.byUuid(j.playerId)
         val newGameState = state.tableState.playerRejoins(pos)
         val newState = state.withPlayer(ctx, j.playerId, j.replyTo, pos)
           .updateGameStateAndTellPlayers(newGameState, ctx.log)
         // make sure the player has the latest state (even if the browser was closed)
-        if (!newState.players.isComplete) {
-          newState.tellJoiningMessagesTo(j.replyTo)
-        } else {
-          newState.tellFullStateTo(j.playerId)
-        }
+        newState.tellWelcomeMessages(j.replyTo, Some(pos))
         behavior(newState)
-      case j: PlayerJoined if !state.players.isComplete =>
+      case j: PlayerJoined if !state.clients.isComplete =>
         val newPos: Option[PlayerPosition] =
-          PlayerPosition.All.find(p => !state.players.byPos.contains(p))
+          PlayerPosition.All.find(p => !state.clients.byPos.contains(p))
         newPos.fold {
           // impossible to reach, but nevertheless:
           ctx.log.warn(s"Could not join even though not all positions are taken: $state")
           Behaviors.same[IncomingAction]
         } { pos =>
           val newState = state.withPlayer(ctx, j.playerId, j.replyTo, pos)
-          if (newState.players.isComplete) {
+          if (newState.clients.isComplete) {
             // reveal the initial game state:
             newState.updateGameStateAndTellPlayers(newState.tableState, ctx.log, force = true)
           } else {
-            newState.tellJoiningMessagesTo(j.replyTo)
+            newState.tellJoiningMessages(j.replyTo)
           }
           behavior(newState)
         }
       case j: PlayerJoined =>
-        ctx.log.warn(s"Player tried to join when table as complete: $state")
-        j.replyTo ! OutgoingAction.NewMessageToClient(MessageToClient.TableIsFull)
-        j.replyTo ! OutgoingAction.Completed
-        Behaviors.same
-      case d: ReceiverDied if state.players.byUuid.contains(d.playerId) =>
-        ctx.log.warn(s"Player ${d.playerId} left (${d.pos}, ${d.receiver.path.name})")
+        ctx.log.info(s"Player tried to join when table as complete - joins as spectator")
+        state.tellWelcomeMessages(j.replyTo, posOpt = None)
+        behavior(state.withSpectator(ctx, j.replyTo))
+      case d: PlayerReceiverDied if state.clients.byUuid.contains(d.playerId) =>
+        ctx.log.info(s"Player ${d.playerId} left (${d.pos}, ${d.receiver.path.name})")
         val stateWithoutReceiver = state.withoutReceiver(d.playerId, d.receiver)
-        val (pos, _) = stateWithoutReceiver.players.byUuid(d.playerId)
-        if (stateWithoutReceiver.players.byPos(pos).nonEmpty) {
+        val (pos, _) = stateWithoutReceiver.clients.byUuid(d.playerId)
+        if (stateWithoutReceiver.clients.byPos(pos).nonEmpty) {
           behavior(stateWithoutReceiver)
         } else {
           val newState = stateWithoutReceiver.tableState.playerPauses(pos)
           behavior(stateWithoutReceiver.updateGameStateAndTellPlayers(newState, ctx.log))
         }
+      case d: SpectatorReceiverDied =>
+        ctx.log.info(s"Spectator left (${d.receiver.path.name})")
+        behavior(state.withoutSpectator(d.receiver))
       case IncomingMessageFromClient(id, SetUserName(name)) =>
-        state.players.byUuid.get(id).fold {
+        state.clients.byUuid.get(id).fold {
           ctx.log.debug(s"Unknown user id, cannot rename: $id")
           Behaviors.same[IncomingAction]
         } { case (pos, _) =>
           val newTableState = state.tableState.withUpdatedUserName(pos, name)
           behavior(state.updateGameStateAndTellPlayers(newTableState, ctx.log))
         }
-      case IncomingMessageFromClient(id, PlayerActionMessage(action)) if state.players.isComplete =>
+      case IncomingMessageFromClient(id, PlayerActionMessage(action)) if state.clients.isComplete =>
         val newGameState = for {
-          (pos, _) <- state.players.byUuid.get(id)
+          (pos, _) <- state.clients.byUuid.get(id)
           gs <- state.tableState.handleAction(pos, action)
         } yield gs
         newGameState.fold {
@@ -204,14 +236,14 @@ object TableActor {
         // termination of outgoing socket-stream (on ReceiverDied)
         ctx.log.debug(s"Player ${l.playerId} leaving")
         Behaviors.same
-      case d: ReceiverDied =>
+      case d: PlayerReceiverDied =>
         ctx.log.debug(s"A player left that was not even playing: $d")
         Behaviors.same
     }
   }
 
   private object State {
-    def apply(implicit rules: Rules): State = State(Players(), FullTableState.apply)
+    def apply(implicit rules: Rules): State = State(Clients(), FullTableState.apply)
   }
 
 }


### PR DESCRIPTION
Do not block any new UUIDs joining
when the table is full - make them
spectators instead.