### PR TITLE
Hide circe behind typedefs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,9 @@ lazy val shared =
         "org.scalacheck" %%% "scalacheck" % Versions.scalaCheckVersion % "test"
       ),
       libraryDependencies ++= Seq(
-        "io.circe" %%% "circe-core"
+        "io.circe" %%% "circe-core",
+        "io.circe" %%% "circe-generic",
+        "io.circe" %%% "circe-parser"
       ).map(_ % Versions.circeVersion)
     )
 
@@ -43,13 +45,7 @@ lazy val client =
       libraryDependencies ++= Seq(
         "org.scala-js" %%% "scalajs-dom" % Versions.scalaJsDomVersion,
         "io.monix" %%% "minitest" % Versions.miniTestVersion % "test"
-      ),
-      // TODO: add cats explicitly here since (it is used via transitive dependency)
-      libraryDependencies ++= Seq(
-        "io.circe" %%% "circe-core",
-        "io.circe" %%% "circe-generic",
-        "io.circe" %%% "circe-parser"
-      ).map(_ % Versions.circeVersion)
+      )
     )
     .dependsOn(sharedJs % "compile->compile;test->test")
 
@@ -73,11 +69,6 @@ lazy val server =
         "ch.qos.logback" % "logback-classic" % Versions.logBackVersion,
         "io.monix" %% "minitest" % Versions.miniTestVersion % "test"
       ),
-      libraryDependencies ++= Seq(
-        "io.circe" %% "circe-core",
-        "io.circe" %% "circe-generic",
-        "io.circe" %% "circe-parser"
-      ).map(_ % Versions.circeVersion),
       Compile / resourceGenerators += Def.task {
         val f1 = (client / Compile / fastOptJS).value.data
         val f1SourceMap = f1.getParentFile / (f1.getName + ".map")

--- a/client/src/main/scala/io/github/mahh/doko/client/Client.scala
+++ b/client/src/main/scala/io/github/mahh/doko/client/Client.scala
@@ -1,6 +1,5 @@
 package io.github.mahh.doko.client
 
-import io.circe
 import io.github.mahh.doko.client.ElementFactory._
 import io.github.mahh.doko.client.strings.BidStrings
 import io.github.mahh.doko.client.strings.ReservationStrings
@@ -21,6 +20,7 @@ import io.github.mahh.doko.shared.game.GameState.ReservationResult
 import io.github.mahh.doko.shared.game.GameState.RoundResults
 import io.github.mahh.doko.shared.game.GameState.WaitingForReservations
 import io.github.mahh.doko.shared.game.Reservation
+import io.github.mahh.doko.shared.json.Json
 import io.github.mahh.doko.shared.msg.MessageToClient
 import io.github.mahh.doko.shared.msg.MessageToClient.GameStateMessage
 import io.github.mahh.doko.shared.msg.MessageToClient.Joining
@@ -91,7 +91,7 @@ object Client {
         writeToArea(s"Failed: $msg")
       }
 
-      override def onUpdate(update: Either[circe.Error, MessageToClient]): Unit = update match {
+      override def onUpdate(update: Either[Json.DecodeError, MessageToClient]): Unit = update match {
         case Left(error) =>
           writeToArea(s"Error reading message from server: $error")
         case Right(Joining) =>

--- a/client/src/main/scala/io/github/mahh/doko/client/Socket.scala
+++ b/client/src/main/scala/io/github/mahh/doko/client/Socket.scala
@@ -1,11 +1,6 @@
 package io.github.mahh.doko.client
 
-import java.util.UUID
-
-import io.circe
-import io.circe.generic.auto._
-import io.circe.parser._
-import io.circe.syntax._
+import io.github.mahh.doko.shared.json.Json
 import io.github.mahh.doko.shared.msg.MessageToClient
 import io.github.mahh.doko.shared.msg.MessageToServer
 import org.scalajs.dom
@@ -14,6 +9,7 @@ import org.scalajs.dom.Event
 import org.scalajs.dom.MessageEvent
 import org.scalajs.dom.WebSocket
 
+import java.util.UUID
 import scala.concurrent.duration.DurationLong
 import scala.language.postfixOps
 import scala.scalajs.js.timers._
@@ -36,7 +32,7 @@ class Socket {
 
   def write(msg: MessageToServer): Unit = socket.foreach { webSocket =>
     if (webSocket.readyState == WebSocket.OPEN) {
-      webSocket.send(msg.asJson.noSpaces)
+      webSocket.send(Json.encode(msg))
     }
   }
 
@@ -89,7 +85,7 @@ class Socket {
     }
     webSocket.onmessage = {
       (event: MessageEvent) =>
-        listener.foreach(_.onUpdate(decode[MessageToClient](event.data.toString)))
+        listener.foreach(_.onUpdate(Json.decode[MessageToClient](event.data.toString)))
     }
     webSocket.onerror = { event =>
       listener.foreach(_.onError(event.toString))
@@ -113,6 +109,6 @@ object Socket {
   trait Listener {
     def onOpen(isReconnect: Boolean): Unit
     def onError(msg: String): Unit
-    def onUpdate(update: Either[circe.Error, MessageToClient]): Unit
+    def onUpdate(update: Either[Json.DecodeError, MessageToClient]): Unit
   }
 }

--- a/shared/src/main/scala/io/github/mahh/doko/shared/json/Json.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/json/Json.scala
@@ -1,0 +1,25 @@
+package io.github.mahh.doko.shared.json
+
+/**
+ * Wraps current json codec implementation (circe) to make it easier to change it.
+ *
+ * The future of circe seems to be uncertain (especially for scala 3), so this shall ensure it will be rather simple to
+ * replase it.
+ */
+object Json {
+
+  type Decoder[A] = io.circe.Decoder[A]
+
+  type Encoder[A] = io.circe.Encoder[A]
+
+  type DecodeError = io.circe.Error
+
+  def decode[A: Decoder](json: String): Either[DecodeError, A] = {
+    io.circe.parser.decode(json)
+  }
+
+  def encode[A: Encoder](a: A): String = {
+    import io.circe.syntax.EncoderOps
+    a.asJson.noSpaces
+  }
+}

--- a/shared/src/main/scala/io/github/mahh/doko/shared/msg/MessageToClient.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/msg/MessageToClient.scala
@@ -1,6 +1,7 @@
 package io.github.mahh.doko.shared.msg
 
 import io.github.mahh.doko.shared.game.GameState
+import io.github.mahh.doko.shared.json.Json
 import io.github.mahh.doko.shared.player.PlayerPosition
 import io.github.mahh.doko.shared.score.TotalScores
 
@@ -29,4 +30,16 @@ object MessageToClient {
 
   /** Response that is sent if a player tries to join a "table" that already has four players. */
   case object TableIsFull extends MessageToClient
+
+  import io.circe.generic.auto._
+  import io.circe.generic.semiauto._
+
+  private[this] val encoder: Json.Encoder[MessageToClient] = deriveEncoder
+
+  private[this] val decoder: Json.Decoder[MessageToClient] = deriveDecoder
+
+  implicit def messageToClientEncoder: Json.Encoder[MessageToClient] = encoder
+
+  implicit def messageToClientDecoder: Json.Decoder[MessageToClient] = decoder
+
 }

--- a/shared/src/main/scala/io/github/mahh/doko/shared/msg/MessageToServer.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/msg/MessageToServer.scala
@@ -1,6 +1,7 @@
 package io.github.mahh.doko.shared.msg
 
 import io.github.mahh.doko.shared.game.GameState
+import io.github.mahh.doko.shared.json.Json
 import io.github.mahh.doko.shared.player.PlayerAction
 
 /**
@@ -14,4 +15,14 @@ object MessageToServer {
 
   case class SetUserName(name: String) extends MessageToServer
 
+  import io.circe.generic.auto._
+  import io.circe.generic.semiauto._
+
+  private[this] val encoder: Json.Encoder[MessageToServer] = deriveEncoder
+
+  private[this] val decoder: Json.Decoder[MessageToServer] = deriveDecoder
+
+  implicit def messageToServerEncoder: Json.Encoder[MessageToServer] = encoder
+
+  implicit def messageToServerDecoder: Json.Decoder[MessageToServer] = decoder
 }

--- a/shared/src/test/scala/io/github/mahh/doko/shared/msg/MessageSpec.scala
+++ b/shared/src/test/scala/io/github/mahh/doko/shared/msg/MessageSpec.scala
@@ -1,0 +1,18 @@
+package io.github.mahh.doko.shared.msg
+
+import io.github.mahh.doko.shared.json.Json
+import io.github.mahh.doko.shared.testutils.Checkers
+import minitest.SimpleTestSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop
+import org.scalacheck.Prop.AnyOperators
+
+abstract class MessageSpec[M: Json.Encoder : Json.Decoder : Arbitrary](msgName: String)
+  extends SimpleTestSuite with Checkers {
+
+  check(s"$msgName can be encoded and then decoded") {
+    Prop.forAll { (msg: M) =>
+      Json.decode[M](Json.encode(msg)) ?= Right(msg)
+    }
+  }
+}

--- a/shared/src/test/scala/io/github/mahh/doko/shared/msg/MessageToClientSpec.scala
+++ b/shared/src/test/scala/io/github/mahh/doko/shared/msg/MessageToClientSpec.scala
@@ -1,0 +1,5 @@
+package io.github.mahh.doko.shared.msg
+
+import io.github.mahh.doko.shared.testutils.DeriveArbitrary._
+
+object MessageToClientSpec extends MessageSpec[MessageToClient]("MessageToClient")

--- a/shared/src/test/scala/io/github/mahh/doko/shared/msg/MessageToServerSpec.scala
+++ b/shared/src/test/scala/io/github/mahh/doko/shared/msg/MessageToServerSpec.scala
@@ -1,0 +1,5 @@
+package io.github.mahh.doko.shared.msg
+
+import io.github.mahh.doko.shared.testutils.DeriveArbitrary._
+
+object MessageToServerSpec extends MessageSpec[MessageToServer]("MessageToServer")


### PR DESCRIPTION
Hide circe behind typedefs so that it may be easier to replace.
Also: add some basic tests for the relevant en-/decoders.