### PR TITLE
Migrate to Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,9 @@ val sharedSettings = Seq(
   scalacOptions ++= Seq(
     "-Xfatal-warnings",
     "-unchecked",
-    "-Wconf:cat=deprecation:e"
+    "-Wconf:cat=deprecation:e",
+    // needed for derivation (of Json typeclasses & of Arbitrary-instances):
+    "-Xmax-inlines:80"
   ),
   testFrameworks += new TestFramework("minitest.runner.Framework")
 )
@@ -17,8 +19,6 @@ lazy val shared =
   (crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure) in file("shared"))
     .settings(sharedSettings)
     .settings(
-      // needed for derivation of Json typeclasses:
-      scalacOptions += "-Xmax-inlines:80",
       libraryDependencies ++= Seq(
         "io.monix" %%% "minitest" % Versions.miniTestVersion % "test",
         "org.scalacheck" %%% "scalacheck" % Versions.scalaCheckVersion % "test"
@@ -75,5 +75,3 @@ lazy val server =
       watchSources ++= (client/ watchSources).value
     )
     .dependsOn(sharedJvm % "compile->compile;test->test", logic)
-
-

--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,9 @@ version := "0.1"
 val sharedSettings = Seq(
   scalaVersion := Versions.scalaVersion,
   scalacOptions ++= Seq(
-    "-deprecation",
-    "-Ymacro-annotations",
     "-Xfatal-warnings",
-    "-Xlint:infer-any",
-    "-Wunused:imports"
+    "-unchecked",
+    "-Wconf:cat=deprecation:e"
   ),
   testFrameworks += new TestFramework("minitest.runner.Framework")
 )
@@ -19,10 +17,10 @@ lazy val shared =
   (crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure) in file("shared"))
     .settings(sharedSettings)
     .settings(
+      // needed for derivation of Json typeclasses:
+      scalacOptions += "-Xmax-inlines:80",
       libraryDependencies ++= Seq(
         "io.monix" %%% "minitest" % Versions.miniTestVersion % "test",
-        // so far, shapeless is only used to derive arbitraries -> test only
-        "com.chuusai" %%% "shapeless" % Versions.shapelessVersion % "test",
         "org.scalacheck" %%% "scalacheck" % Versions.scalaCheckVersion % "test"
       ),
       libraryDependencies ++= Seq(
@@ -64,8 +62,8 @@ lazy val server =
     .settings(sharedSettings)
     .settings(
       libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-stream-typed" % Versions.akkaVersion,
-        "com.typesafe.akka" %% "akka-http" % Versions.akkaHttpVersion,
+        ("com.typesafe.akka" %% "akka-stream-typed" % Versions.akkaVersion).cross(CrossVersion.for3Use2_13),
+        ("com.typesafe.akka" %% "akka-http" % Versions.akkaHttpVersion).cross(CrossVersion.for3Use2_13),
         "ch.qos.logback" % "logback-classic" % Versions.logBackVersion,
         "io.monix" %% "minitest" % Versions.miniTestVersion % "test"
       ),

--- a/logic/src/main/scala/io/github/mahh/doko/logic/rules/DeckRule.scala
+++ b/logic/src/main/scala/io/github/mahh/doko/logic/rules/DeckRule.scala
@@ -22,5 +22,5 @@ object DeckRule {
 
   case object WithoutNines extends DeckRule(_ != Rank.Nine)
 
-  val all: List[DeckRule] = List(WithNines, WithoutNines)
+  def all: List[DeckRule] = List(WithNines, WithoutNines)
 }

--- a/logic/src/test/scala/io/github/mahh/doko/logic/game/PlayingSpec.scala
+++ b/logic/src/test/scala/io/github/mahh/doko/logic/game/PlayingSpec.scala
@@ -18,7 +18,7 @@ import io.github.mahh.doko.shared.player.PlayerPosition._
 import io.github.mahh.doko.shared.rules.Trumps
 import io.github.mahh.doko.shared.score.TotalScores
 import io.github.mahh.doko.shared.table.TableMap
-import io.github.mahh.doko.shared.testutils.DeriveArbitrary._
+import io.github.mahh.doko.shared.testutils.DeriveArbitrary.given
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalacheck.Prop

--- a/logic/src/test/scala/io/github/mahh/doko/logic/game/RuleConformingGens.scala
+++ b/logic/src/test/scala/io/github/mahh/doko/logic/game/RuleConformingGens.scala
@@ -17,6 +17,7 @@ import io.github.mahh.doko.shared.player.PlayerPosition
 import io.github.mahh.doko.shared.score.TotalScores
 import io.github.mahh.doko.shared.table.TableMap
 import io.github.mahh.doko.shared.table.TableMapGens
+import io.github.mahh.doko.shared.testutils.DeriveArbitrary.given
 import io.github.mahh.doko.shared.testutils.GenUtils
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
@@ -29,7 +30,6 @@ import scala.reflect.ClassTag
  */
 object RuleConformingGens {
 
-  import io.github.mahh.doko.shared.testutils.DeriveArbitrary._
 
   implicit val rulesArb: Arbitrary[Rules] = Arbitrary(Gen.resultOf(Rules(_: DeckRule)))
 
@@ -378,7 +378,7 @@ object RuleConformingGens {
     // TODO: include "poverty" - this currently does not generate Playing-states resulting
     //  from a player calling "poverty".
     val filter: ReservationFilter = {
-      import ReservationFilter._
+      import ReservationFilter.*
       reservationFilter && notPoverty && notThrowing
     }
     collectSomeState[FullGameState.Playing](

--- a/logic/src/test/scala/io/github/mahh/doko/logic/game/TeamAnalyzerSpec.scala
+++ b/logic/src/test/scala/io/github/mahh/doko/logic/game/TeamAnalyzerSpec.scala
@@ -4,13 +4,12 @@ import io.github.mahh.doko.shared.bids.Bid
 import io.github.mahh.doko.shared.player.PlayerPosition
 import io.github.mahh.doko.shared.table.TableMap
 import io.github.mahh.doko.shared.testutils.Checkers
+import io.github.mahh.doko.shared.testutils.DeriveArbitrary.given
 import minitest.SimpleTestSuite
 import org.scalacheck.Prop
 import org.scalacheck.Prop.AnyOperators
 
 object TeamAnalyzerSpec extends SimpleTestSuite with Checkers {
-
-  import io.github.mahh.doko.shared.testutils.DeriveArbitrary._
 
   check("result of split teams contains all input players") {
     Prop.forAll { (players: TableMap[Role]) =>

--- a/logic/src/test/scala/io/github/mahh/doko/logic/score/ScoreAnalyzerSpec.scala
+++ b/logic/src/test/scala/io/github/mahh/doko/logic/score/ScoreAnalyzerSpec.scala
@@ -1,8 +1,8 @@
 package io.github.mahh.doko.logic.score
 
-import io.github.mahh.doko.shared.deck.Rank._
-import io.github.mahh.doko.shared.deck.Suit._
-import io.github.mahh.doko.shared.deck._
+import io.github.mahh.doko.shared.deck.*
+import io.github.mahh.doko.shared.deck.Rank.*
+import io.github.mahh.doko.shared.deck.Suit.*
 import io.github.mahh.doko.shared.game.CompleteTrick
 import io.github.mahh.doko.shared.player.PlayerPosition
 import io.github.mahh.doko.shared.player.PlayerPosition.Player1
@@ -12,15 +12,15 @@ import io.github.mahh.doko.shared.player.PlayerPosition.Player4
 import io.github.mahh.doko.shared.score.Score
 import io.github.mahh.doko.shared.table.TableMap
 import io.github.mahh.doko.shared.testutils.Checkers
+import io.github.mahh.doko.shared.testutils.DeriveArbitrary.given
 import minitest.SimpleTestSuite
+import org.scalacheck.Arbitrary
 import org.scalacheck.Prop
 
 object ScoreAnalyzerSpec extends SimpleTestSuite with Checkers {
 
-  import io.github.mahh.doko.shared.testutils.DeriveArbitrary._
-
   test("if winner of last trick played jack of diamonds, she scored Charly") {
-    import PlayerPosition._
+    import PlayerPosition.*
     val trick = CompleteTrick(
       Player1,
       TableMap(
@@ -35,7 +35,7 @@ object ScoreAnalyzerSpec extends SimpleTestSuite with Checkers {
   }
 
   test("if winner of last trick did not play jack of diamonds, but her teammate did, they did not score Charly") {
-    import PlayerPosition._
+    import PlayerPosition.*
     val trick = CompleteTrick(
       Player1,
       TableMap(
@@ -50,7 +50,7 @@ object ScoreAnalyzerSpec extends SimpleTestSuite with Checkers {
   }
 
   test("if winner of last trick catches jack of diamonds from the other team, she scored CharlyCaught") {
-    import PlayerPosition._
+    import PlayerPosition.*
     val trick = CompleteTrick(
       Player1,
       TableMap(
@@ -65,7 +65,7 @@ object ScoreAnalyzerSpec extends SimpleTestSuite with Checkers {
   }
 
   test("if another trick than the last was won via jack of diamonds, no one scored Charly") {
-    import PlayerPosition._
+    import PlayerPosition.*
     val previousTrick = CompleteTrick(
       Player1,
       TableMap(

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,6 +1,6 @@
 object Versions {
 
-  val scalaVersion = "2.13.4"
+  val scalaVersion = "3.1.1"
 
   val akkaVersion = "2.6.19"
   val akkaHttpVersion = "10.2.9"

--- a/shared/src/main/scala/io/github/mahh/doko/shared/bids/Bid.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/bids/Bid.scala
@@ -1,5 +1,6 @@
 package io.github.mahh.doko.shared.bids
 
+import io.github.mahh.doko.shared.json.Json._
 import io.github.mahh.doko.shared.utils.OrderingFromSeq
 
 sealed trait Bid
@@ -9,7 +10,7 @@ object Bid {
   /**
    * Adds the "is elders" information so that the name of the bid ("re"/"kontra") can be derived.
    */
-  case class NameableBid(isElders: Boolean, bid: Bid)
+  case class NameableBid(isElders: Boolean, bid: Bid) derives Encoder, Decoder
 
   val All: List[Bid] = Win :: BidExtension.All
 

--- a/shared/src/main/scala/io/github/mahh/doko/shared/deck/Card.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/deck/Card.scala
@@ -1,6 +1,8 @@
 package io.github.mahh.doko.shared.deck
 
-case class Card(suit: Suit, rank: Rank) {
+import io.github.mahh.doko.shared.json.Json._
+
+case class Card(suit: Suit, rank: Rank) derives Encoder, Decoder {
   override def toString: String = f"[$suit${rank.shortName}%2s]"
 
   def value: Int = rank.value

--- a/shared/src/main/scala/io/github/mahh/doko/shared/game/Reservation.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/game/Reservation.scala
@@ -1,11 +1,12 @@
 package io.github.mahh.doko.shared.game
 
+import io.github.mahh.doko.shared.json.Json._
 import io.github.mahh.doko.shared.rules.Trumps
 
 /**
  * Aka "Vorbehalt".
  */
-sealed trait Reservation
+sealed trait Reservation derives Encoder, Decoder
 
 object Reservation {
 

--- a/shared/src/main/scala/io/github/mahh/doko/shared/json/Json.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/json/Json.scala
@@ -1,16 +1,26 @@
 package io.github.mahh.doko.shared.json
 
+import scala.deriving.Mirror
+
 /**
  * Wraps current json codec implementation (circe) to make it easier to change it.
  *
  * The future of circe seems to be uncertain (especially for scala 3), so this shall ensure it will be rather simple to
- * replase it.
+ * replace it.
  */
 object Json {
 
   type Decoder[A] = io.circe.Decoder[A]
 
   type Encoder[A] = io.circe.Encoder[A]
+
+  // decorate the companions to enable "derives Encoder, Decoder" syntax:
+
+  extension (companion: io.circe.Decoder.type)
+    inline def derived[A](using m: Mirror.Of[A]): Decoder[A] = io.circe.generic.semiauto.deriveDecoder
+
+  extension (companion: io.circe.Encoder.type)
+    inline def derived[A](using m: Mirror.Of[A]): Encoder[A] = io.circe.generic.semiauto.deriveEncoder
 
   type DecodeError = io.circe.Error
 

--- a/shared/src/main/scala/io/github/mahh/doko/shared/msg/MessageToClient.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/msg/MessageToClient.scala
@@ -1,14 +1,14 @@
 package io.github.mahh.doko.shared.msg
 
 import io.github.mahh.doko.shared.game.GameState
-import io.github.mahh.doko.shared.json.Json
+import io.github.mahh.doko.shared.json.Json._
 import io.github.mahh.doko.shared.player.PlayerPosition
 import io.github.mahh.doko.shared.score.TotalScores
 
 /**
  * Messages that are sent from server to client (via websocket).
  */
-sealed trait MessageToClient
+sealed trait MessageToClient derives Encoder, Decoder
 
 object MessageToClient {
 
@@ -30,16 +30,5 @@ object MessageToClient {
 
   /** Response that is sent if a player tries to join a "table" that already has four players. */
   case object TableIsFull extends MessageToClient
-
-  import io.circe.generic.auto._
-  import io.circe.generic.semiauto._
-
-  private[this] val encoder: Json.Encoder[MessageToClient] = deriveEncoder
-
-  private[this] val decoder: Json.Decoder[MessageToClient] = deriveDecoder
-
-  implicit def messageToClientEncoder: Json.Encoder[MessageToClient] = encoder
-
-  implicit def messageToClientDecoder: Json.Decoder[MessageToClient] = decoder
 
 }

--- a/shared/src/main/scala/io/github/mahh/doko/shared/msg/MessageToServer.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/msg/MessageToServer.scala
@@ -1,13 +1,13 @@
 package io.github.mahh.doko.shared.msg
 
 import io.github.mahh.doko.shared.game.GameState
-import io.github.mahh.doko.shared.json.Json
+import io.github.mahh.doko.shared.json.Json._
 import io.github.mahh.doko.shared.player.PlayerAction
 
 /**
  * Messages that are sent from client to server (via websocket).
  */
-sealed trait MessageToServer
+sealed trait MessageToServer derives Encoder, Decoder
 
 object MessageToServer {
 
@@ -15,14 +15,4 @@ object MessageToServer {
 
   case class SetUserName(name: String) extends MessageToServer
 
-  import io.circe.generic.auto._
-  import io.circe.generic.semiauto._
-
-  private[this] val encoder: Json.Encoder[MessageToServer] = deriveEncoder
-
-  private[this] val decoder: Json.Decoder[MessageToServer] = deriveDecoder
-
-  implicit def messageToServerEncoder: Json.Encoder[MessageToServer] = encoder
-
-  implicit def messageToServerDecoder: Json.Decoder[MessageToServer] = decoder
 }

--- a/shared/src/main/scala/io/github/mahh/doko/shared/player/PlayerPosition.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/player/PlayerPosition.scala
@@ -2,11 +2,12 @@ package io.github.mahh.doko.shared.player
 
 import io.circe.KeyDecoder
 import io.circe.KeyEncoder
+import io.github.mahh.doko.shared.json.Json._
 
 /**
  * Position of a player at the table.
  */
-sealed trait PlayerPosition
+sealed trait PlayerPosition derives Encoder, Decoder
 
 object PlayerPosition {
 

--- a/shared/src/main/scala/io/github/mahh/doko/shared/score/Score.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/score/Score.scala
@@ -1,13 +1,14 @@
 package io.github.mahh.doko.shared.score
 
 import io.github.mahh.doko.shared.bids.Bid.BidExtension
+import io.github.mahh.doko.shared.json.Json._
 
 /**
  * Scores that can be achieved during a round of doppelkopf.
  *
  * @param value The value of each score.
  */
-sealed abstract class Score(val value: Int)
+sealed abstract class Score(val value: Int) derives Encoder, Decoder
 
 object Score {
 

--- a/shared/src/main/scala/io/github/mahh/doko/shared/score/Scores.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/score/Scores.scala
@@ -2,6 +2,7 @@ package io.github.mahh.doko.shared.score
 
 import cats.instances.all._
 import cats.syntax.all._
+import io.github.mahh.doko.shared.json.Json._
 import io.github.mahh.doko.shared.player.PlayerPosition
 import io.github.mahh.doko.shared.score.Scores.TeamScore
 
@@ -14,7 +15,7 @@ import io.github.mahh.doko.shared.score.Scores.TeamScore
 case class Scores(
   eldersScore: TeamScore,
   othersScore: TeamScore
-) {
+) derives Encoder, Decoder {
   def all: List[TeamScore] = List(eldersScore, othersScore)
 
   def totals: List[Int] = {

--- a/shared/src/main/scala/io/github/mahh/doko/shared/score/TotalScores.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/score/TotalScores.scala
@@ -2,6 +2,7 @@ package io.github.mahh.doko.shared.score
 
 import cats.instances.all._
 import cats.syntax.all._
+import io.github.mahh.doko.shared.json.Json._
 import io.github.mahh.doko.shared.player.PlayerPosition
 
 /**
@@ -9,7 +10,7 @@ import io.github.mahh.doko.shared.player.PlayerPosition
  *
  * @param scores The scores since start of the game (in reverse / "newest score first" order).
  */
-case class TotalScores(scores: List[Scores]) {
+case class TotalScores(scores: List[Scores]) derives Encoder, Decoder {
   def addScores(additionalScores: Scores): TotalScores = copy(scores = additionalScores :: scores)
 
   def sumPerPlayer: Map[PlayerPosition, Int] = scores.foldMap(_.totalsPerPlayer)

--- a/shared/src/test/scala/io/github/mahh/doko/shared/msg/MessageToClientSpec.scala
+++ b/shared/src/test/scala/io/github/mahh/doko/shared/msg/MessageToClientSpec.scala
@@ -1,5 +1,5 @@
 package io.github.mahh.doko.shared.msg
 
-import io.github.mahh.doko.shared.testutils.DeriveArbitrary._
+import io.github.mahh.doko.shared.testutils.DeriveArbitrary.given
 
 object MessageToClientSpec extends MessageSpec[MessageToClient]("MessageToClient")

--- a/shared/src/test/scala/io/github/mahh/doko/shared/msg/MessageToServerSpec.scala
+++ b/shared/src/test/scala/io/github/mahh/doko/shared/msg/MessageToServerSpec.scala
@@ -1,5 +1,5 @@
 package io.github.mahh.doko.shared.msg
 
-import io.github.mahh.doko.shared.testutils.DeriveArbitrary._
+import io.github.mahh.doko.shared.testutils.DeriveArbitrary.given
 
 object MessageToServerSpec extends MessageSpec[MessageToServer]("MessageToServer")

--- a/shared/src/test/scala/io/github/mahh/doko/shared/testutils/DeriveArbitrary.scala
+++ b/shared/src/test/scala/io/github/mahh/doko/shared/testutils/DeriveArbitrary.scala
@@ -2,57 +2,52 @@ package io.github.mahh.doko.shared.testutils
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
-import shapeless._
-import shapeless.ops.coproduct.Length
-import shapeless.ops.nat.ToInt
+
+import scala.compiletime.erasedValue
+import scala.compiletime.summonInline
+import scala.deriving.*
 
 /**
- * Simple support for shapeless based derivation of `Arbitrary`s.
+ * Simple support for derivation of `Arbitrary`s.
  *
  * @note There's also [[https://github.com/alexarchambault/scalacheck-shapeless]] for this purpose,
- *       but this is simple, does the job and avoids yet another external dependency.
+ *       but that is not available for scala 3.
  */
-object DeriveArbitrary extends ProductTypeClassCompanion[Arbitrary] {
+object DeriveArbitrary {
 
-  object typeClass extends ProductTypeClass[Arbitrary] {
+  inline private def summonAll[T <: Tuple]: Tuple =
+    inline erasedValue[T] match
+      case _: EmptyTuple => EmptyTuple
+      case _: (t *: ts) => summonInline[Arbitrary[t]] *: summonAll[ts]
 
-    override def product[H, T <: HList](ch: Arbitrary[H], ct: Arbitrary[T]): Arbitrary[H :: T] = Arbitrary {
-      for {
-        h <- ch.arbitrary
-        t <- ct.arbitrary
-      } yield h :: t
-    }
-
-    override def emptyProduct: Arbitrary[HNil] = Arbitrary(Gen.const(HNil))
-
-    override def project[F, G](instance: => Arbitrary[G], to: F => G, from: G => F): Arbitrary[F] = Arbitrary {
-      instance.arbitrary.map(from)
-    }
-
-    def coproduct[L, R <: Coproduct, N <: Nat](
-      cl: => Arbitrary[L],
-      cr: => Arbitrary[R],
-      rl: => Length.Aux[R, N],
-      toInt: => ToInt[N]
-    ): Arbitrary[L :+: R] = Arbitrary {
-      Gen.frequency(
-        1 -> cl.arbitrary.map(Inl(_)),
-        toInt() -> cr.arbitrary.map(Inr(_))
-      )
-    }
+  inline private def arbitrarySum[T](s: Mirror.SumOf[T]): Arbitrary[T] =
+    val elems = summonAll[s.MirroredElemTypes]
+    elems.toList.asInstanceOf[List[Arbitrary[T]]] match
+      case arb :: Nil => arb
+      case gen0 :: gen1 :: gens => Arbitrary(Gen.oneOf(gen0.arbitrary, gen1.arbitrary, gens.map(_.arbitrary):_*))
+      case Nil => Arbitrary(Gen.fail)
 
 
-    def emptyCoproduct: Arbitrary[CNil] = Arbitrary(Gen.fail)
+  inline private def arbitraryTuple[T <: Tuple]: Arbitrary[Tuple] =
+    inline erasedValue[T] match
+      case _: EmptyTuple =>
+        Arbitrary(Gen.const(EmptyTuple))
+      case _: (t *: ts) =>
+        val genT = for {
+          tVal <- summonInline[Arbitrary[t]].arbitrary
+          tsVal <- arbitraryTuple[ts].arbitrary
+        } yield tVal *: tsVal
+        Arbitrary(genT)
 
-  }
+  inline private def arbitraryProduct[T](p: Mirror.ProductOf[T]): Arbitrary[T] =
+    Arbitrary(arbitraryTuple[p.MirroredElemTypes].arbitrary.map(p.fromProduct(_)))
 
-  implicit def deriveCNil: Arbitrary[CNil] = typeClass.emptyCoproduct
+  inline given derived[T](using m: Mirror.Of[T]): Arbitrary[T] =
+    inline m match
+      case s: Mirror.SumOf[T] => arbitrarySum(s)
+      case p: Mirror.ProductOf[T] => arbitraryProduct(p)
 
-  implicit def deriveCCons[H, T <: Coproduct, N <: Nat](
-    implicit ch: Lazy[Arbitrary[H]],
-    ct: Lazy[Arbitrary[T]],
-    rt: Lazy[Length.Aux[T, N]],
-    toInt: Lazy[ToInt[N]]
-  ): Arbitrary[H :+: T] = typeClass.coproduct(ch.value, ct.value, rt.value, toInt.value)
+  // implicit resolution fails with some strange error if we don't provide this:
+  inline given listArb[T: Arbitrary]: Arbitrary[List[T]] = Arbitrary.arbContainer[List, T]
 
 }


### PR DESCRIPTION
This is a bit unsatisfying because derivation of circe typeclasses is not working as flawless as with scala 2. However: it does work with a little bit more boilerplate.