### PR TITLE
Move more logic to logic module

### DIFF
--- a/logic/src/main/scala/io/github/mahh/doko/logic/table/TableClients.scala
+++ b/logic/src/main/scala/io/github/mahh/doko/logic/table/TableClients.scala
@@ -22,6 +22,9 @@ case class TableClients[Ref](
 
   def allReceivers: Set[Ref] = spectators ++ byPos.values.flatten
 
+  def posForUUID(uuid: UUID): Option[PlayerPosition] =
+    byUuid.get(uuid).map { case (pos, _) => pos }
+
   def withPlayer(id: UUID, clientRef: Ref, pos: PlayerPosition): TableClients[Ref] = {
     val existingOpt = byUuid.get(id)
     if (existingOpt.exists { case (p, _) => p != pos }) {

--- a/server/src/main/scala/io/github/mahh/doko/server/Routes.scala
+++ b/server/src/main/scala/io/github/mahh/doko/server/Routes.scala
@@ -71,8 +71,8 @@ class Routes(tableActor: ActorRef[IncomingAction])(implicit system: ActorSystem)
       .to(
         ActorSink.actorRef(
           tableActor,
-          IncomingAction.PlayerLeaving(connectionId, None),
-          e => IncomingAction.PlayerLeaving(connectionId, Some(e))
+          IncomingAction.ClientLeaving(connectionId, None),
+          e => IncomingAction.ClientLeaving(connectionId, Some(e))
         )
       )
 
@@ -84,7 +84,7 @@ class Routes(tableActor: ActorRef[IncomingAction])(implicit system: ActorSystem)
         OverflowStrategy.fail
       )
       .mapMaterializedValue { ref =>
-        tableActor ! IncomingAction.PlayerJoined(connectionId, ref)
+        tableActor ! IncomingAction.ClientJoined(connectionId, ref)
       }
       .collect { case OutgoingAction.NewMessageToClient(s) =>
         s

--- a/server/src/main/scala/io/github/mahh/doko/server/tableactor/IncomingAction.scala
+++ b/server/src/main/scala/io/github/mahh/doko/server/tableactor/IncomingAction.scala
@@ -16,7 +16,7 @@ object IncomingAction {
   /**
    * Incoming socket connection has been opened.
    */
-  case class PlayerJoined(
+  case class ClientJoined(
     playerId: UUID,
     replyTo: ActorRef[OutgoingAction]
   ) extends IncomingAction
@@ -32,28 +32,18 @@ object IncomingAction {
   /**
    * Incoming socket connection has been closed.
    */
-  case class PlayerLeaving(
+  case class ClientLeaving(
     playerId: UUID,
     failureOpt: Option[Throwable]
   ) extends IncomingAction
 
   /**
-   * Incoming socket connection of a player has been fully disposed.
+   * Incoming socket connection of a client has been fully disposed.
    *
    * (This is send via deathwatch when the actor for outgoing messages has died.)
    */
-  case class PlayerReceiverDied(
-    playerId: UUID,
-    pos: PlayerPosition,
-    receiver: ActorRef[OutgoingAction]
-  ) extends IncomingAction
-
-  /**
-   * Incoming socket connection of a spectator has been fully disposed.
-   *
-   * (This is send via deathwatch when the actor for outgoing messages has died.)
-   */
-  case class SpectatorReceiverDied(
+  case class ClientDied(
+    clientId: UUID,
     receiver: ActorRef[OutgoingAction]
   ) extends IncomingAction
 }

--- a/shared/src/main/scala/io/github/mahh/doko/shared/utils/OptionUtil.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/utils/OptionUtil.scala
@@ -1,0 +1,5 @@
+package io.github.mahh.doko.shared.utils
+
+extension [A](opt: Option[A])
+  def toEither[E](ifEmpty: => E): Either[E, A] =
+    opt.fold(Left(ifEmpty))(Right.apply)


### PR DESCRIPTION
Moves a lot of logic from (akka-dependent) TableActor to (akka-independent, purely functional) TableServerState.

Also: some minor general refactoring of related code, e.g. improve some naming.