### PR TITLE
Alternative, actor-less server implementation

### DIFF
--- a/logic/src/main/scala/io/github/mahh/doko/logic/table/TableServerState.scala
+++ b/logic/src/main/scala/io/github/mahh/doko/logic/table/TableServerState.scala
@@ -224,6 +224,11 @@ object TableServerState {
 
   type TransitionOutput[Ref] = (TableServerState[Ref], Vector[ClientMessageTask[Ref]])
 
+  object TransitionOutput {
+    def initial[Ref](using rules: Rules): TransitionOutput[Ref] =
+      TableServerState.apply[Ref] -> Vector.empty[ClientMessageTask[Ref]]
+  }
+
   sealed trait TableServerError
 
   object TableServerError {

--- a/server/src/main/scala/io/github/mahh/doko/server/ServerMain.scala
+++ b/server/src/main/scala/io/github/mahh/doko/server/ServerMain.scala
@@ -13,6 +13,7 @@ import io.github.mahh.doko.logic.rules.DeckRule
 import io.github.mahh.doko.logic.rules.Rules
 import io.github.mahh.doko.server.tableactor.ActorBasedLogicFlowFactory
 import io.github.mahh.doko.server.tableactor.TableActor
+import io.github.mahh.doko.server.tableflow.FlowBasedLogicFlowFactory
 import org.slf4j.LoggerFactory
 
 import java.io.InputStream
@@ -43,7 +44,9 @@ object ServerMain extends App {
       // TODO: configurable rules - make this configurable
       implicit val rules: Rules = Rules(DeckRule.WithNines)
 
-      val flowFactory = new ActorBasedLogicFlowFactory(ctx)
+      val flowFactory =
+        // new FlowBasedLogicFlowFactory
+        new ActorBasedLogicFlowFactory(ctx)
 
       val routes = new Routes(flowFactory)
 

--- a/server/src/main/scala/io/github/mahh/doko/server/tableflow/ClientId.scala
+++ b/server/src/main/scala/io/github/mahh/doko/server/tableflow/ClientId.scala
@@ -1,0 +1,6 @@
+package io.github.mahh.doko.server.tableflow
+
+private opaque type ClientId = java.util.UUID
+
+private object ClientId:
+  def random(): ClientId = java.util.UUID.randomUUID()

--- a/server/src/main/scala/io/github/mahh/doko/server/tableflow/IncomingAction.scala
+++ b/server/src/main/scala/io/github/mahh/doko/server/tableflow/IncomingAction.scala
@@ -1,0 +1,22 @@
+package io.github.mahh.doko.server.tableflow
+
+import io.github.mahh.doko.logic.table.participant.ParticipantId
+import io.github.mahh.doko.shared.msg.MessageToServer
+
+private trait IncomingAction
+
+private object IncomingAction:
+  case class ClientJoined(
+    clientId: ClientId,
+    participantId: ParticipantId
+  ) extends IncomingAction
+
+  case class IncomingMessage(
+    participantId: ParticipantId,
+    msg: MessageToServer
+  ) extends IncomingAction
+
+  case class ClientLeft(
+    clientId: ClientId,
+    participantId: ParticipantId
+  ) extends IncomingAction

--- a/server/src/main/scala/io/github/mahh/doko/server/tableflow/TableFlow.scala
+++ b/server/src/main/scala/io/github/mahh/doko/server/tableflow/TableFlow.scala
@@ -1,0 +1,105 @@
+package io.github.mahh.doko.server.tableflow
+
+import akka.NotUsed
+import akka.event.Logging
+import akka.event.slf4j.Logger
+import akka.stream.Attributes
+import akka.stream.Materializer
+import akka.stream.scaladsl.BroadcastHub
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.MergeHub
+import akka.stream.scaladsl.RunnableGraph
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import io.github.mahh.doko.logic.rules.Rules
+import io.github.mahh.doko.logic.table.ClientMessageTask
+import io.github.mahh.doko.logic.table.TableServerState
+import io.github.mahh.doko.logic.table.TableServerState.TransitionOutput
+import io.github.mahh.doko.logic.table.participant.ParticipantId
+import io.github.mahh.doko.server.LogicFlowFactory
+import io.github.mahh.doko.server.tableflow
+import io.github.mahh.doko.server.tableflow.IncomingAction.ClientJoined
+import io.github.mahh.doko.server.tableflow.IncomingAction.ClientLeft
+import io.github.mahh.doko.shared.msg.MessageToClient
+import io.github.mahh.doko.shared.msg.MessageToServer
+import io.github.mahh.doko.shared.msg.MessageToServer.PlayerActionMessage
+import io.github.mahh.doko.shared.msg.MessageToServer.SetUserName
+
+/** State transition logic. */
+private def applyIncoming(
+  state: TableServerState[ClientId],
+  in: IncomingAction
+): TransitionOutput[ClientId] =
+  import IncomingAction.*
+  in match
+    case cj: ClientJoined =>
+      state.applyClientJoined(cj.participantId, cj.clientId)
+    case IncomingMessage(participantId, SetUserName(name)) =>
+      state.applyUserNameChange(participantId, name).getOrElse(state -> Vector.empty)
+    case IncomingMessage(participantId, PlayerActionMessage(action)) =>
+      state.applyPlayerAction(participantId, action).getOrElse(state -> Vector.empty)
+    case cl: ClientLeft =>
+      state.applyClientLeft(cl.participantId, cl.clientId).getOrElse(state -> Vector.empty)
+
+class FlowBasedLogicFlowFactory(using materializer: Materializer, rules: Rules)
+  extends LogicFlowFactory {
+
+  import FlowBasedLogicFlowFactory.*
+
+  private val (sink, source) = tableFlow.run()
+
+  override def flowForParticipant(
+    id: ParticipantId
+  ): Flow[MessageToServer, MessageToClient, NotUsed] = {
+    Flow[MessageToServer]
+      // flatMapPrefix(0) so that it is ensured that ClientId.random() gets called at runtime,
+      // resulting in a different ID for each materialized instance
+      .flatMapPrefix(0) { _ =>
+        gameFlow(id, ClientId.random(), sink, source)
+      }
+  }
+}
+
+object FlowBasedLogicFlowFactory {
+
+  // typedefs for the sake of sane line lengths:
+
+  private type TableFlowSink = Sink[IncomingAction, NotUsed]
+
+  private type TableFlowSource = Source[Map[ClientId, Vector[MessageToClient]], NotUsed]
+
+  // the core server logic: dynamic fan-in -> a state machine (using .scan) -> dynamic fan-out
+  private def tableFlow(
+    using rules: Rules
+  ): RunnableGraph[(TableFlowSink, TableFlowSource)] =
+    MergeHub
+      .source[IncomingAction]
+      .scan(TransitionOutput.initial[ClientId]) { case ((state, _), in) =>
+        applyIncoming(state, in)
+      }
+      .map { case (_, out) => out.groupMap(_.clientRef)(_.message) }
+      .toMat(BroadcastHub.sink)(Keep.both)
+
+  // connects a single client to the fan-in and fan-out stages of a `tableFlow`
+  private def gameFlow(
+    participantId: ParticipantId,
+    clientId: ClientId,
+    logicIn: TableFlowSink,
+    logicOut: TableFlowSource
+  ): Flow[MessageToServer, MessageToClient, NotUsed] = {
+
+    val sink = Flow[MessageToServer]
+      .map(IncomingAction.IncomingMessage(participantId, _))
+      .prepend(Source.single(IncomingAction.ClientJoined(clientId, participantId)))
+      .concat(Source.single(IncomingAction.ClientLeft(clientId, participantId)))
+      .recover { case _ => IncomingAction.ClientLeft(clientId, participantId) }
+      .to(logicIn)
+
+    val source =
+      logicOut
+        .mapConcat(_.getOrElse(clientId, Vector.empty))
+
+    Flow.fromSinkAndSourceCoupled(sink, source)
+  }
+}


### PR DESCRIPTION
Adds an alternative solution that does not rely on actors and only uses streams instead. This might be a better template to migrate the server away from akka.