### PR TITLE
Client: remove Client.getInstance()

### DIFF
--- a/client/src/main/scala/io/github/mahh/doko/client/Client.scala
+++ b/client/src/main/scala/io/github/mahh/doko/client/Client.scala
@@ -48,8 +48,6 @@ import org.scalajs.dom.*
  */
 object Client {
 
-  protected def getInstance(): this.type = this
-
   private def elementById[E <: Element](elementId: String): E = {
     dom.document.getElementById(elementId).asInstanceOf[E]
   }


### PR DESCRIPTION
This was not used and there is no obvious reason for its existence.

(It might have been needed in earlier versions of scala-js.)