### PR TITLE
Remove workaround for initialization bug

### DIFF
--- a/shared/src/main/scala/io/github/mahh/doko/shared/rules/Trumps.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/rules/Trumps.scala
@@ -67,10 +67,7 @@ object Trumps {
 
     case object JacksSolo extends CourtSolo(J)
 
-    // TODO: this should be a val, but there seem to be some strange initialization order problems
-    //  due to which sometimes members of this are null if this is a val - these should be analyzed
-    //  and fixed differently
-    def All: List[Solo] =
+    val All: List[Solo] =
       List(QueensSolo, JacksSolo, ClubsSolo, SpadesSolo, HeartsSolo, DiamondsSolo)
 
   }


### PR DESCRIPTION
Due to the change from Scala 2 to 3, there's good reason to hope it has been fixed. However: this is just hope (but let's give it a try).