### PR TITLE
Revert "Remove workaround for initialization bug"

### DIFF
--- a/shared/src/main/scala/io/github/mahh/doko/shared/rules/Trumps.scala
+++ b/shared/src/main/scala/io/github/mahh/doko/shared/rules/Trumps.scala
@@ -67,7 +67,10 @@ object Trumps {
 
     case object JacksSolo extends CourtSolo(J)
 
-    val All: List[Solo] =
+    // TODO: this should be a val, but there seem to be some strange initialization order problems
+    //  due to which sometimes members of this are null if this is a val - these should be analyzed
+    //  and fixed differently
+    def All: List[Solo] =
       List(QueensSolo, JacksSolo, ClubsSolo, SpadesSolo, HeartsSolo, DiamondsSolo)
 
   }


### PR DESCRIPTION
Turns out that the bug still exists (see pipeline of [!109](https://github.com/MartinHH/lkdoko/pull/109)).

This reverts commit 19dcfefb10282bdc80694ebfdc262d5fcf5abcac.