### PR TITLE
Test: improve DeriveArbitrary for sealed traits

### DIFF
--- a/shared/src/test/scala/io/github/mahh/doko/shared/testutils/DeriveArbitrarySpec.scala
+++ b/shared/src/test/scala/io/github/mahh/doko/shared/testutils/DeriveArbitrarySpec.scala
@@ -116,14 +116,11 @@ object DeriveArbitrarySpec {
 
   object ComplexADTWithNestedMembers {
     val expectedGen: Gen[ComplexADTWithNestedMembers] =
-      // TODO: ideally, derivation would result in a equal distribution across all four members
       Gen.oneOf(
         Gen.const(AnotherCaseObject),
-        Gen.oneOf(
-          AbstractSubClass.SubclassA.expectedGen,
-          AbstractSubClass.SubclassB.expectedGen,
-          AbstractSubClass.SubclassC.expectedGen
-        )
+        AbstractSubClass.SubclassA.expectedGen,
+        AbstractSubClass.SubclassB.expectedGen,
+        AbstractSubClass.SubclassC.expectedGen
       )
   }
 }


### PR DESCRIPTION
Ensure "equal distribution" across all inheriting classes of a sealed trait (even if they inherit transitively via a sealed sub-trait).